### PR TITLE
[Bug] Prevent present function from being called from background thread

### DIFF
--- a/Deprecator/Source/Deprecator.swift
+++ b/Deprecator/Source/Deprecator.swift
@@ -77,6 +77,8 @@ public final class Deprecator
                 let decoder = JSONDecoder()
                 let deprecations = try decoder.decode(Deprecations.self, from: unwrappedData)
 
+                // First check that there is a minimum deprecation.
+                // If there is one, then it takes priority.
                 if let minimumDeprecation = deprecations.minimumDeprecation,
                        minimumDeprecation.buildNumber > weakSelf.currentBuildNumber
                 {
@@ -84,8 +86,8 @@ public final class Deprecator
                     return
                 }
                 
-                // First check that there is a preferred deprecation.
-                // If there is one and a minumum deprecation then it takes priority
+                // Check if there is a preferred deprecation.
+                // This will only be called if there is no minimum deprecation.
                 if let preferredDeprecation = deprecations.preferredDeprecation,
                        preferredDeprecation.buildNumber > weakSelf.currentBuildNumber
                 {

--- a/Deprecator/Source/Models/Deprecation.swift
+++ b/Deprecator/Source/Models/Deprecation.swift
@@ -66,7 +66,9 @@ public struct Deprecation: Decodable
         }
         
         // Present
-        viewController.present(alertController, animated: true, completion: nil)
+        DispatchQueue.main.async {
+            viewController.present(alertController, animated: true, completion: nil)
+        }
     }
 }
 

--- a/Deprecator/Source/Models/Deprecation.swift
+++ b/Deprecator/Source/Models/Deprecation.swift
@@ -40,7 +40,7 @@ public struct Deprecation: Decodable
     
     // MARK: Alerts
     
-    public func present(in viewController: UIViewController, language: String? = nil)
+    public func present(in viewController: UIViewController, language: String? = nil, completion: (() -> Void)? = nil)
     {
         var languageStrings = self.defaultLanguageStrings
         if let unwrappedLanguage = language,
@@ -66,7 +66,7 @@ public struct Deprecation: Decodable
         }
         
         // Present
-        viewController.present(alertController, animated: true, completion: nil)
+        viewController.present(alertController, animated: true, completion: completion)
     }
 }
 


### PR DESCRIPTION
On iOS 13, calling the present(_:animated:completion:) function will cause a crash if
called in the background thread, so we have to make sure it is called from the main thread.