### PR TITLE
Fix minor issues introduced while using framework

### DIFF
--- a/Deprecator/Source/Deprecator.swift
+++ b/Deprecator/Source/Deprecator.swift
@@ -77,6 +77,8 @@ public final class Deprecator
                 let decoder = JSONDecoder()
                 let deprecations = try decoder.decode(Deprecations.self, from: unwrappedData)
 
+                // First check that there is a minimum deprecation.
+                // If there is one, then it takes priority.
                 if let minimumDeprecation = deprecations.minimumDeprecation,
                        minimumDeprecation.buildNumber > weakSelf.currentBuildNumber
                 {
@@ -84,8 +86,8 @@ public final class Deprecator
                     return
                 }
                 
-                // First check that there is a preferred deprecation.
-                // If there is one and a minumum deprecation then it takes priority
+                // Check if there is a preferred deprecation.
+                // This will only be called if there is no minimum deprecation.
                 if let preferredDeprecation = deprecations.preferredDeprecation,
                        preferredDeprecation.buildNumber > weakSelf.currentBuildNumber
                 {

--- a/Deprecator/Source/Models/Deprecation.swift
+++ b/Deprecator/Source/Models/Deprecation.swift
@@ -40,7 +40,8 @@ public struct Deprecation: Decodable
     
     // MARK: Alerts
     
-    public func present(in viewController: UIViewController, language: String? = nil, completion: (() -> Void)? = nil)
+    public func present(in viewController: UIViewController, language: String? = nil, completion: (() -> Void)? = nil,
+                        didDismiss: ((_ success: Bool) -> Void)? = nil)
     {
         var languageStrings = self.defaultLanguageStrings
         if let unwrappedLanguage = language,
@@ -55,13 +56,16 @@ public struct Deprecation: Decodable
         // Update action
         let updateAction = UIAlertAction(title: languageStrings.updateTitle, style: .default) { (action) in
             UIApplication.shared.open(self.appStoreURL, options: [:], completionHandler: nil)
+            didDismiss?(true)
         }
         alertController.addAction(updateAction)
         
         // Cancel button
         if let cancelTitle = languageStrings.cancelTitle
         {
-            let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel, handler: nil)
+            let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel) { (action) in
+                didDismiss?(false)
+            }
             alertController.addAction(cancelAction)
         }
         

--- a/Deprecator/Source/Models/Deprecation.swift
+++ b/Deprecator/Source/Models/Deprecation.swift
@@ -66,7 +66,9 @@ public struct Deprecation: Decodable
         }
         
         // Present
-        viewController.present(alertController, animated: true, completion: nil)
+        DispatchQueue.main.async {
+            viewController.present(alertController, animated: true, completion: nil)
+        }
     }
 }
 

--- a/Deprecator/Source/Models/Deprecation.swift
+++ b/Deprecator/Source/Models/Deprecation.swift
@@ -40,7 +40,7 @@ public struct Deprecation: Decodable
     
     // MARK: Alerts
     
-    public func present(in viewController: UIViewController, language: String? = nil)
+    public func present(in viewController: UIViewController, language: String? = nil, completion: (() -> Void)? = nil)
     {
         var languageStrings = self.defaultLanguageStrings
         if let unwrappedLanguage = language,
@@ -66,7 +66,7 @@ public struct Deprecation: Decodable
         }
         
         // Present
-        viewController.present(alertController, animated: true, completion: nil)
+        viewController.present(alertController, animated: true, completion: completion)
     }
 }
 


### PR DESCRIPTION
This pull request contains minor changes to the documentation of Deprecator, making it clear which step of the deprecation check has priority. 

It also contains changes to the present function in Deprecation to make sure it is run in the main thread on iOS 13 and allow the client to have its own completion function in case they need to do extra work once the alert has completed its presentation or was dismissed.